### PR TITLE
Fix(stock): 銘柄登録画面のセクターと国をドロップダウンリストに変更

### DIFF
--- a/modules/web/src/main/resources/templates/stockRegister.html
+++ b/modules/web/src/main/resources/templates/stockRegister.html
@@ -24,11 +24,16 @@
             </div>
             <div>
                 <label for="country">国:</label>
-                <input type="text" id="country" name="country" required />
+                <select id="country" name="country" required>
+                    <option value="jp">jp</option>
+                    <option value="us">us</option>
+                </select>
             </div>
             <div>
-                <label for="sector_name">セクター名:</label>
-                <input type="text" id="sector_name" name="sector_name" required />
+                <label for="sector_id">セクター名:</label>
+                <select id="sector_id" name="sector_id" required>
+                    <option th:each="sector : ${sectors}" th:value="${sector.id}" th:text="${sector.name}"></option>
+                </select>
             </div>
             <input type="submit" value="登録" />
         </form>


### PR DESCRIPTION
銘柄登録画面のセクターと国を、テキスト入力からドロップダウンリストでの選択形式に変更しました。

- 国は'jp'と'us'から選択できます。
- セクターはDBに登録されているセクターマスタから動的に読み込まれます。
- フォーム送信時に、セクター名ではなくセクターIDが送信されるように修正しました。