### PR TITLE
Add an NGINX proxy to the docker-compose setup.

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,12 +4,22 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - "8080:8080"
     volumes:
       - db:/app/data
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+      - /home/vscode/.htpasswd:/etc/nginx/conf.d/.htpasswd
+    depends_on:
+      - app
+
 volumes:
   db:
     driver: local

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        auth_basic "Restricted Content";
+        auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
+
+        proxy_pass http://app:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
This change introduces an NGINX container that acts as a reverse proxy for the 'app' service.

Key changes:
- Adds an `nginx` service to `compose.yml`.
- The NGINX service exposes port 80, replacing the previous 8080 port from the 'app' service.
- The 'app' service is no longer directly exposed to the host.
- NGINX is configured to enforce Basic Authentication.
- The password file (`.htpasswd`) is expected to be mounted from `/home/vscode/.htpasswd` on the host.
- A new `nginx/nginx.conf` file contains the proxy and authentication configuration.