### PR TITLE
Fix: stock.htmlの削除ボタンが機能しない問題を修正

### DIFF
--- a/modules/web/src/main/resources/templates/stock.html
+++ b/modules/web/src/main/resources/templates/stock.html
@@ -48,10 +48,7 @@
                         <a th:href="@{/stock/edit/{id}(id=${stock.id})}">編集</a>
                     </td>
                     <td>
-                        <form th:action="@{/stock/delete}" method="post" onsubmit="return confirm('本当に削除しますか？');">
-                            <input type="hidden" name="id" th:value="${stock.id}" />
-                            <input type="submit" value="削除" />
-                        </form>
+                        <a href="#" th:onclick="'javascript:deleteStock(' + ${stock.id} + '); return false;'">削除</a>
                     </td>
                 </tr>
             </tbody>
@@ -64,6 +61,23 @@
             checkboxes = document.getElementsByName('selectedIds');
             for (var i = 0, n = checkboxes.length; i < n; i++) {
                 checkboxes[i].checked = source.checked;
+            }
+        }
+
+        function deleteStock(stockId) {
+            if (confirm('本当に削除しますか？')) {
+                var form = document.createElement('form');
+                form.method = 'post';
+                form.action = /*[[@{/stock/delete}]]*/ '/stock/delete';
+
+                var idInput = document.createElement('input');
+                idInput.type = 'hidden';
+                idInput.name = 'id';
+                idInput.value = stockId;
+                form.appendChild(idInput);
+
+                document.body.appendChild(form);
+                form.submit();
             }
         }
     </script>


### PR DESCRIPTION
stock.htmlにおいて、削除ボタンがネストされたformタグ内に配置されていたため、ブラウザによっては正しく機能しない問題がありました。特に、リストの最初のアイテムで問題が報告されていました。

この修正では、ネストされたフォームを削除し、代わりにJavaScriptを使用して動的にフォームを生成し、POSTリクエストを送信するように変更しました。これにより、HTMLの構造が正しくなり、すべての削除ボタンが意図通りに機能するようになります。

- 削除ボタンを`<a>`タグに変更し、`onclick`イベントでJavaScript関数`deleteStock(id)`を呼び出すように修正。
- `deleteStock(id)`関数を`stock.html`に追加。この関数は確認ダイアログを表示し、ユーザーの承認後に削除リクエストを送信します。