### PR TITLE
Fix(stock): Yahooファイナンスの株価取得処理を更新

### DIFF
--- a/modules/stock/src/main/kotlin/com/example/stock/model/StockData.kt
+++ b/modules/stock/src/main/kotlin/com/example/stock/model/StockData.kt
@@ -39,7 +39,7 @@ data class Stock(
 
     @field:Min(0, message = "current_priceは0以上の数字である必要があります")
     @Column(name = "current_price")
-    val current_price: Int? = null,
+    val current_price: Double? = null,
 
     @Column(name = "latest_dividend")
     val latestDividend: Double? = null,

--- a/modules/stock/src/main/kotlin/com/example/stock/provider/StockInfo.kt
+++ b/modules/stock/src/main/kotlin/com/example/stock/provider/StockInfo.kt
@@ -3,7 +3,7 @@ package com.example.stock.provider
 import java.time.LocalDate
 
 data class StockInfo(
-    val price: Int?,
+    val price: Double?,
     val dividend: Double?,
     val earningsDate: LocalDate?
 )


### PR DESCRIPTION
YahooファイナンスのHTML構造の変更に対応するため、株価情報の取得方法を更新しました。

変更点:
- これまでのHTML要素の直接スクレイピングから、ページに埋め込まれたJSON (`window.__PRELOADED_STATE__`) をパースする方法に変更しました。これにより、サイトのレイアウト変更に対する耐性が向上します。
- 株価が小数点を含むことがあるため、価格を格納するフィールドのデータ型を`Int`から`Double`に変更しました (`Stock.current_price` および `StockInfo.price`)。
- 配当金、業績発表日、銘柄名の取得ロジックも、同様にJSONから取得するように修正しました。