### PR TITLE
feat: Yahooファイナンスへのアクセスに遅延を追加

### DIFF
--- a/modules/stock/build.gradle.kts
+++ b/modules/stock/build.gradle.kts
@@ -10,6 +10,12 @@ java {
     sourceCompatibility = JavaVersion.VERSION_17 // Java Versionを指定
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
 dependencies {
     // Webアプリケーション、JPAに必要な基本的な依存関係
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/modules/stock/src/main/kotlin/com/example/stock/provider/YahooFinanceProvider.kt
+++ b/modules/stock/src/main/kotlin/com/example/stock/provider/YahooFinanceProvider.kt
@@ -3,12 +3,16 @@ package com.example.stock.provider
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.jsoup.Jsoup
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 import java.util.regex.Pattern
 
 @Component
-class YahooFinanceProvider : FinanceProvider {
+class YahooFinanceProvider(
+    @Value("\${yahoo.finance.request.delay.millis:1000}")
+    private val requestDelayMillis: Long
+) : FinanceProvider {
 
     companion object {
         private const val BASE_URL = "https://finance.yahoo.co.jp/quote"
@@ -18,6 +22,8 @@ class YahooFinanceProvider : FinanceProvider {
     private val objectMapper = ObjectMapper()
 
     override fun fetchStockInfo(code: String, country: String): StockInfo? {
+        Thread.sleep(requestDelayMillis)
+
         if (country.lowercase() != "jp") {
             return null
         }
@@ -39,6 +45,8 @@ class YahooFinanceProvider : FinanceProvider {
     }
 
     override fun fetchStockName(code: String, country: String): String? {
+        Thread.sleep(requestDelayMillis)
+
         if (country.lowercase() != "jp") {
             return null
         }

--- a/modules/web/build.gradle.kts
+++ b/modules/web/build.gradle.kts
@@ -10,6 +10,12 @@ java {
     sourceCompatibility = JavaVersion.VERSION_17 // Java Versionを指定
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
 // Spring Boot Webアプリに必要な依存関係を追加
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web") // SpringbootWebフレームワーク


### PR DESCRIPTION
Yahooファイナンスへのアクセススピードを抑えるため、1件当たりの取得間隔を設定できるようにします。 デフォルトは1秒です。

プロパティ `yahoo.finance.request.delay.millis` でミリ秒単位で間隔を調整できます。

また、ビルドエラーを修正するために、Gradleのビルドファイルを更新しました。