### PR TITLE
feat: Add editing for stock price and dividend

### DIFF
--- a/modules/web/src/main/kotlin/com/example/stock/controller/StockController.kt
+++ b/modules/web/src/main/kotlin/com/example/stock/controller/StockController.kt
@@ -98,18 +98,36 @@ class StockController(
         @RequestParam("code") code: String,
         @RequestParam("name") name: String,
         @RequestParam("country") country: String,
-        @RequestParam("sector_id.id") sectorId: Int
+        @RequestParam("sector_id.id") sectorId: Int,
+        @RequestParam("current_price", required = false) currentPrice: Double?,
+        @RequestParam("latestDividend", required = false) latestDividend: Double?
     ): String {
         val sector = sectorService.findById(sectorId)
             ?: throw IllegalArgumentException("Sector not found: $sectorId")
 
-        val stock = Stock(
-            id = id,
-            code = code,
-            name = name,
-            country = country,
-            sector_id = sector
-        )
+        val stock = if (id != 0) {
+            // IDがある場合は既存のエンティティを更新
+            val existingStock = stockService.findById(id)
+                ?: throw IllegalArgumentException("Invalid stock Id:$id")
+            existingStock.copy(
+                code = code,
+                name = name,
+                country = country,
+                sector_id = sector,
+                current_price = currentPrice,
+                latestDividend = latestDividend
+            )
+        } else {
+            // IDがない場合は新しいエンティティを作成
+            Stock(
+                code = code,
+                name = name,
+                country = country,
+                sector_id = sector,
+                current_price = currentPrice,
+                latestDividend = latestDividend
+            )
+        }
 
         stockService.save(stock)
         return "redirect:/stock"

--- a/modules/web/src/main/resources/templates/stock_edit.html
+++ b/modules/web/src/main/resources/templates/stock_edit.html
@@ -30,6 +30,14 @@
                     <option th:each="sector : ${sectors}" th:value="${sector.id}" th:text="${sector.name}"></option>
                 </select>
             </div>
+            <div>
+                <label for="current_price">現在の株価:</label>
+                <input type="number" step="any" id="current_price" th:field="*{current_price}" />
+            </div>
+            <div>
+                <label for="latestDividend">最新配当(円):</label>
+                <input type="number" step="any" id="latestDividend" th:field="*{latestDividend}" />
+            </div>
             <input type="submit" th:value="${stock.id == null} ? '登録' : '更新'" />
         </form>
         <script>


### PR DESCRIPTION
This change introduces the ability for users to edit the current price and latest dividend of a stock through the stock edit form.

- Adds `current_price` and `latestDividend` input fields to `stock_edit.html`.
- Updates `StockController`'s `saveStock` method to handle these new fields.
- Refactors the `saveStock` method to use a safer "fetch-update-save" pattern when updating existing stocks.